### PR TITLE
Pretty String representation of case classes with field names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.cache
+.lib/
+.idea/
+.idea_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # spy
+
+Library for Scala 2.13+ projects for pretty printing case classes with 
+field names and in hierarchical tree format. Useful for debugging purposes as it
+gives human readable representation of case classes. Provides `.spy` extension
+method for any object.
+
+```
+libraryDependencies += "com.gu" %% "spy" % "0.1.0"
+```
+
+Example usage
+
+```scala
+import com.gu.spy._
+case class Address(street: String, city: String, planet: String, country: String)
+case class User(name: String, age: Int, address: Address)
+val user = User("Jean-Luc Picard", 79, Address("Starfleet", "San Francisco", "Earth", "United Federation of Planets"))
+println(user.spy)
+```
+
+
+#### `println(user)`
+
+```
+User(Jean-Luc Picard,79,Address(Starfleet,San Francisco,Earth,United Federation of Planets))
+```
+
+#### `println(user.spy)`
+
+```
+User
+  name: Jean-Luc Picard
+  age: 79
+  address: Address
+    street: Starfleet
+    city: San Francisco
+    planet: Earth
+    country: United Federation of Planets
+```
+
+## Credits
+
+* Based on Xavier Guihot's StackOverflow [answer](https://stackoverflow.com/a/55032051/5205022). 
+* [Case Class toString new behavior proposal](https://contributors.scala-lang.org/t/case-class-tostring-new-behavior-proposal-with-implementation/2056/44?u=mario-galic)
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,28 @@
+import sbtrelease.ReleaseStateTransformations._
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "spy",
+    description := "Pretty printed human readable String inspection of Scala objects",
+    organization := "com.gu",
+    organizationName := "The Guardian",
+    scalaVersion := "2.13.1",
+    Compile / doc / sources := List(),
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+    releaseProcess := Seq[ReleaseStep](
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      publishArtifacts,
+      setNextVersion,
+      commitNextVersion,
+      releaseStepCommand("sonatypeReleaseAll"),
+      pushChanges
+    ),
+    libraryDependencies += "org.scalameta" %% "munit" % "0.7.2" % Test,
+  )
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.github.gseitz"        %   "sbt-release"                 % "1.0.13")
+addSbtPlugin("com.jsuereth"             %   "sbt-pgp"                     % "2.0.1")
+addSbtPlugin("org.xerial.sbt"           %   "sbt-sonatype"                % "3.9.2")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,9 @@
+sonatypeProfileName := "com.gu"
+publishMavenStyle := true
+licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+homepage := Some(url("https://github.com/guardian/spy"))
+scmInfo := Some(ScmInfo(url("https://github.com/guardian/spy"), "scm:git@github.com:guardian/spy.git"))
+developers := List(
+  Developer(id="mario-galic", name="Mario Galic", email="", url=url("https://github.com/mario-galic")),
+)
+publishTo := sonatypePublishTo.value

--- a/src/main/scala/com/gu/spy/package.scala
+++ b/src/main/scala/com/gu/spy/package.scala
@@ -1,0 +1,29 @@
+package com.gu
+
+package object spy {
+  implicit class SpyOps(obj: Any) {
+    def spy: String = {
+      val builder = new StringBuilder
+
+      def loop(obj: Any, depth: Int, paramName: Option[String]): Unit = {
+        val indent = "  " * depth
+        val prettyName = paramName.fold("")(x => s"$x: ")
+        val ptype = obj match { case _: Iterable[Any] => "" case obj: Product => obj.productPrefix case _ => obj.toString }
+
+        builder append s"$indent$prettyName$ptype\n"
+
+        obj match {
+          case seq: Iterable[Any] =>
+            seq.foreach(loop(_, depth + 1, None))
+          case obj: Product =>
+            (obj.productIterator zip obj.productElementNames)
+              .foreach { case (subObj, paramName) => loop(subObj, depth + 1, Some(paramName)) }
+          case _ =>
+        }
+      }
+
+      loop(obj, 0, None)
+      builder.toString
+    }
+  }
+}

--- a/src/test/scala/com/gu/spy/SpySuite.scala
+++ b/src/test/scala/com/gu/spy/SpySuite.scala
@@ -1,0 +1,21 @@
+package com.gu.spy
+
+class SpySuite extends munit.FunSuite {
+  test("spy") {
+    case class Address(planet: String, city: String)
+    case class User(name: String, age: Int, address: Address)
+    val user = User("Picard", 75, Address("Earth", "San Francisco"))
+
+    val expected =
+      """
+        |User
+        |  name: Picard
+        |  age: 75
+        |  address: Address
+        |    planet: Earth
+        |    city: San Francisco
+        |""".stripMargin
+
+    assertEquals(user.spy, expected)
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"
+version in ThisBuild := "0.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
Make use of Scala 2.13 [`Product#productElementName`](https://www.scala-lang.org/api/current/scala/Product.html#productElementName(n:Int):String) based on [Xavier's](https://stackoverflow.com/a/55032051/5205022) answer to pretty print case classes with field names

```scala
import com.gu.spy._
case class Address(street: String, city: String, planet: String, country: String)
case class User(name: String, age: Int, address: Address)
val user = User("Jean-Luc Picard", 79, Address("Starfleet", "San Francisco", "Earth", "United Federation of Planets"))
println(user.spy)
```

outputs

```scala
User
  name: Jean-Luc Picard
  age: 79
  address: Address
    street: Starfleet
    city: San Francisco
    planet: Earth
    country: United Federation of Planets
```
